### PR TITLE
fix and feat and breaking changes

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -29,7 +29,9 @@ A downloader for E-Hentai / Exhentai collections, developed in Python 3.11, with
 - [x] Generate `ComicInfo.xml` (supports Komga/LANraragi)
 - [x] Zip compression for Komga/LANraragi compatibility
 - [x] LANraragi tag additions
-
+- [ ] Recalculate the waiting time based on `IP quota`
+- [ ] Display the remaining `IP quota`
+- [ ] Optimize the strategy for **This gallery has an updated version available**
 
 
 ![main](/img/main.png)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/eezd/EhFavDL/main)](https://github.com/eezd/EhFavDL/commits/main)
 [![License](https://img.shields.io/badge/license-MIT-yellowgreen.svg)](LICENSE)
 
-E-Hentai / Exhentai 下载收藏夹，基于 Python3.11 编，支持 Komga 和 LANraragi。
+E-Hentai / Exhentai 下载收藏夹，基于 Python3.11 编写，支持 Komga 和 LANraragi。
 
 [中文](README.md)/[English](README-EN.md)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ E-Hentai / Exhentai 下载收藏夹，基于 Python3.11 编写，支持 Komga �
 - [x] 生成 `ComicInfo.xml` (支持 Komga/LANraragi)
 - [x] 压缩成 zip 适配 Komga/LANraragi
 - [x] LANraragi 添加 EH Tags
+- [ ] 根据 `IP quota` 重新计算等待时间
+- [ ] 显示剩余的 `IP quota`
+- [ ] 优化 **此图库有更新的版本可用** 的策略
 
 ![main](/img/main.png)
 

--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def main():
                 print("2. Checker().sync_local_to_sqlite_zip()")
                 print("3. Checker().sync_local_to_sqlite_zip(True)")
                 print("4. Checker().check_loc_file()")
+                print("5. add_fav_data.translate_tags()")
                 num = input("(Options) Select Number:")
                 num = int(num) if num else None
                 if num == 1:
@@ -96,6 +97,8 @@ def main():
                     Checker().sync_local_to_sqlite_zip(True)
                 elif num == 4:
                     Checker().check_loc_file()
+                elif num == 5:
+                    asyncio.run(add_fav_data.translate_tags())
                 elif num == 0:
                     break
 

--- a/src/AddFavData.py
+++ b/src/AddFavData.py
@@ -7,7 +7,6 @@ import sys
 
 from bs4 import BeautifulSoup
 from loguru import logger
-import requests
 from tqdm import tqdm
 
 from .Config import Config
@@ -25,14 +24,9 @@ class AddFavData(Config):
         # 下载最新的标签翻译数据库
         database_url = "https://github.com/EhTagTranslation/Database/releases/latest/download/db.text.json"
         database_name = "db.text.json"
-        try:
-            with requests.get(database_url, stream=True) as r:
-                r.raise_for_status()
-                with open(database_name, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=4096):
-                        f.write(chunk)
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"Failed to download the latest database: {e}")
+        r = await self.fetch_data(database_url)
+        with open(database_name, 'wb') as f:
+            f.write(r)
 
         # 加载数据库中的标签数据
         with open(database_name, 'r', encoding='utf-8') as file:
@@ -287,7 +281,7 @@ class AddFavData(Config):
                         if get_all:
                             co.execute('DELETE FROM gid_tid WHERE gid =?', (data[13],))
                             co.commit()
-                        
+
                         # 添加 tag 数据时我的代码总是会漏一些 gid_tid 的映射 (一般应该不会太多)
                         # 我还没找到原因(，重复 1~2 次 add_tags_data(False) 情况应该会改善一些，代码在下面 line 306
                         tags = ast.literal_eval(data[10])
@@ -302,9 +296,10 @@ class AddFavData(Config):
                     co.commit()
 
                     progress_bar.update(piece)
-            
+
             # 检查遗漏数据，一般不会太多
-            missed_tag = co.execute('SELECT gid FROM eh_data WHERE gid NOT IN (SELECT gid FROM gid_tid WHERE gid IS NOT NULL)').fetchall()
+            missed_tag = co.execute(
+                'SELECT gid FROM eh_data WHERE gid NOT IN (SELECT gid FROM gid_tid WHERE gid IS NOT NULL)').fetchall()
             if len(missed_tag) >= 50:
                 await self.add_tags_data()
 
@@ -312,8 +307,7 @@ class AddFavData(Config):
         with sqlite3.connect(self.dbs_name) as co:
             if gid_list:
                 placeholders = ','.join('?' for _ in gid_list)
-                # 这里不需要删除 eh_data 吗？
-                # co.execute(f'DELETE FROM eh_data WHERE gid IN ({placeholders})', gid_list)
+                co.execute(f'DELETE FROM eh_data WHERE gid IN ({placeholders})', gid_list)
                 co.execute(f'DELETE FROM fav_category WHERE gid IN ({placeholders})', gid_list)
                 co.execute(f'DELETE FROM gid_tid WHERE gid IN ({placeholders})', gid_list)
                 co.commit()
@@ -327,10 +321,11 @@ class AddFavData(Config):
         await self.add_tags_data()
 
         with sqlite3.connect(self.dbs_name) as co:
-            # 这里不需要删除 eh_data 吗？
-            # co.execute('DELETE FROM eh_data WHERE gid IN (SELECT gid FROM fav_category WHERE del_flag = 1 AND original_flag = 0 AND web_1280x_flag = 0)')
-            co.execute('DELETE FROM gid_tid WHERE gid IN (SELECT gid FROM fav_category WHERE del_flag = 1 AND original_flag = 0 AND web_1280x_flag = 0)')
-            # 先提交确保子查询有效
+            co.execute(
+                'DELETE FROM eh_data WHERE gid IN (SELECT gid FROM fav_category WHERE del_flag = 1 AND original_flag = 0 AND web_1280x_flag = 0)')
+            co.commit()
+            co.execute(
+                'DELETE FROM gid_tid WHERE gid IN (SELECT gid FROM fav_category WHERE del_flag = 1 AND original_flag = 0 AND web_1280x_flag = 0)')
             co.commit()
             co.execute('DELETE FROM fav_category WHERE del_flag = 1 AND original_flag = 0 AND web_1280x_flag = 0')
             co.commit()

--- a/src/AddFavData.py
+++ b/src/AddFavData.py
@@ -307,9 +307,10 @@ class AddFavData(Config):
         with sqlite3.connect(self.dbs_name) as co:
             if gid_list:
                 placeholders = ','.join('?' for _ in gid_list)
-                co.execute(f'DELETE FROM eh_data WHERE gid IN ({placeholders})', gid_list)
+                # 假如删除了, 那么他就丢失了该 "已下载" 画廊的所有信息
+                # co.execute(f'DELETE FROM eh_data WHERE gid IN ({placeholders})', gid_list)
                 co.execute(f'DELETE FROM fav_category WHERE gid IN ({placeholders})', gid_list)
-                co.execute(f'DELETE FROM gid_tid WHERE gid IN ({placeholders})', gid_list)
+                # co.execute(f'DELETE FROM gid_tid WHERE gid IN ({placeholders})', gid_list)
                 co.commit()
 
     @logger.catch()

--- a/src/Config.py
+++ b/src/Config.py
@@ -185,7 +185,6 @@ class Config:
                 "expunged" INTEGER NOT NULL DEFAULT 0 /*是否被隐藏*/,
                 "copyright_flag" INTEGER NOT NULL DEFAULT 0 /*是否被版权*/,
                 "rating" TEXT /*评分*/,
-                "tags" TEXT /*标签*/,
                 "current_gid" INTEGER /*画廊最新gid*/,
                 "current_token" TEXT /*画廊最新token*/
             )''')
@@ -205,6 +204,23 @@ class Config:
               "original_flag" INTEGER NOT NULL DEFAULT 0 /* 1表示 通过archiver中original选择下载原图*/,
               "web_1280x_flag" INTEGER NOT NULL DEFAULT 0 /* 1表示 通过网页画廊下载/通过archiver中Resample选项下载*/
             )''')
+            
+            # 使用单独的标签列表和映射表相比字符串存储或许能实现更好的数据统计和管理
+            co.execute('''
+                CREATE TABLE IF NOT EXISTS tag_list (
+                    tid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tag TEXT UNIQUE NOT NULL,
+                    translated_tag TEXT
+                )
+            ''')
+            co.execute('''
+                CREATE TABLE IF NOT EXISTS gid_tid (
+                    gid INTEGER UNSIGNED NOT NULL,
+                    tid INTEGER UNSIGNED NOT NULL,
+                    PRIMARY KEY (gid, tid),
+                    UNIQUE(gid, tid)
+                )
+            ''')
 
             co.commit()
             

--- a/src/DownloadWebGallery.py
+++ b/src/DownloadWebGallery.py
@@ -41,7 +41,7 @@ class DownloadWebGallery(Config):
             real_url = BeautifulSoup(real_url, 'html.parser')
             real_url = real_url.select_one('img#img').get('src')
             if real_url == "https://exhentai.org/img/509.gif":
-                logger.warning("509:YOU HAVE TEMPORARILY REACHED THE LIMIT")
+                logger.warning("509: YOU HAVE TEMPORARILY REACHED THE LIMIT")
                 if self.get_image_limits() == False:
                         logger.warning("Can't get image limits as the account has been suspended, Attempt to wait for 12 hours")
                         # 账号已被暂停，无法访问配额页面，等待12小时配额自行恢复 / The account has been suspended
@@ -53,7 +53,7 @@ class DownloadWebGallery(Config):
                         time.sleep(3600)
                         image_limits,_=self.get_image_limits()
                         print(f"Currently at {image_limits}")
-                        if image_limits <= 200:
+                        if int(image_limits) <= 200:
                             break
                 return await self.download_image(semaphore, url, file_path)
             file = await self.fetch_data(url=real_url)
@@ -112,6 +112,12 @@ class DownloadWebGallery(Config):
                 page_img_url.append([img_url, filename])
 
             sub_ptb = sub_ptb + 1
+            
+        if len(page_img_url)==0:
+            # 加载到https://exhentai.org/img/blank.gif
+            logger.warning("Failed to get image urls, retrying after 30mins……")
+            time.sleep(30 * 60)
+            return await self.get_image_url()
 
         return page_img_url
 

--- a/src/DownloadWebGallery.py
+++ b/src/DownloadWebGallery.py
@@ -74,18 +74,18 @@ class DownloadWebGallery(Config):
             real_url = await self.fetch_data(url=url)
             real_url = BeautifulSoup(real_url, 'html.parser')
             real_url = real_url.select_one('img#img').get('src')
-            # 配额用尽，返回的real_url会变成509.gif
+            # 配额用尽，返回的 real_url 会变成509.gif
             if real_url == "https://exhentai.org/img/509.gif":
                 logger.warning("509: YOU HAVE TEMPORARILY REACHED THE LIMIT")
                 if self.get_image_limits() == False:
-                    # 账号已被暂停，无法访问配额页面，等待12小时配额自行恢复(10hits/min) / The account has been suspended
+                    # 账号已被暂停，无法访问配额页面，等待12小时配额自行恢复 (10hits/min) / The account has been suspended
                     logger.warning("Can't get image limits as the account has been suspended, Attempt to wait for 12 hours")
                     time.sleep(12 * 60 * 60)
                 else:
                     image_limits,total_limits=self.get_image_limits()
                     logger.warning(f"Currently at {image_limits} towards the limit of {total_limits}. Waiting for quota restoration")
                     while True:
-                        # 每隔一小时检查配额是否恢复(恢复速率10hits/min) / Check every hour to see if the quota is restored
+                        # 每隔一小时检查配额是否恢复 (恢复速率 10hits/min) / Check every hour to see if the quota is restored
                         time.sleep(3600)
                         image_limits,_=self.get_image_limits()
                         print(f"Currently at {image_limits}")
@@ -119,7 +119,7 @@ class DownloadWebGallery(Config):
             if copyright_msg.find('copyright') != -1:
                 return "copyright"
         
-        # 获取页面上显示的pages，用于校验是否获取到全部的page_img_url
+        # 获取页面上显示的 pages，用于校验是否获取到全部的 page_img_url
         pages = None
         lengthtd = page_data.find('td', text='Length:')
         if lengthtd:
@@ -158,7 +158,8 @@ class DownloadWebGallery(Config):
             sub_ptb = sub_ptb + 1
             
         if len(page_img_url)==0:
-            # 加载到https://exhentai.org/img/blank.gif，导致获取链接为空
+            # 加载到 https://exhentai.org/img/blank.gif，导致获取链接为空
+            # 往往几个小时也不见恢复，这到底是为什么呢
             logger.warning("Failed to get image urls, retrying after 30mins……")
             time.sleep(30 * 60)
             return await self.get_image_url()

--- a/src/Support.py
+++ b/src/Support.py
@@ -107,16 +107,16 @@ class Support(Config):
                 if db_data is None:
                     logger.warning(f"The ID does not exist>> {gid}")
                     sys.exit(1)
-                    
+
                 # 获取 tid 列表 / Get tid_list
                 tid_list = co.execute(f'SELECT tid FROM gid_tid WHERE gid="{gid}"').fetchall()
                 tid_list = [tid[0] for tid in tid_list]
-                
+
                 # 在 tag_list 中查询对应 tag
                 placeholders = ','.join(['?'] * len(tid_list))
                 tag_list = co.execute(f'SELECT tag FROM tag_list WHERE tid IN ({placeholders})', tid_list).fetchall()
                 db_tags = [tag[0] for tag in tag_list]
-                
+
                 xml_t = xml_escape(db_data[0])
                 category = db_data[1]
 
@@ -172,99 +172,110 @@ class Support(Config):
         if enter != "":
             sys.exit(1)
 
-        authorization_token_base64 = str(base64.b64encode(self.lan_api_psw.encode('utf-8'))).replace("b",
-                                                                                                     "").replace("'",
-                                                                                                                 "")
-
-        return aiohttp.ClientSession(headers={"Authorization": f"Bearer {authorization_token_base64}"})
+        authorization_token_base64 = base64.b64encode(self.lan_api_psw.encode('utf-8')).decode('utf-8')
+        return authorization_token_base64
 
     @logger.catch()
     async def lan_update_tags(self):
-        session = self.lan_request()
-        lan_url = self.lan_url
+        authorization_token_base64 = self.lan_request()
+        headers = {"Authorization": f"Bearer {authorization_token_base64}"}
 
-        if lan_url[-1] == "/":
-            lan_url += "api/archives"
-        else:
-            lan_url += "/api/archives"
+        async with aiohttp.ClientSession(headers=headers) as session:
+            lan_url = self.lan_url
 
-        async with session.get(lan_url) as response:
-            all_archives = await response.json(content_type=None)
+            if lan_url[-1] == "/":
+                lan_url += "api/archives"
+            else:
+                lan_url += "/api/archives"
 
-        logger.info(f"一共检查到 {len(all_archives)} 个")
-        logger.info(f"A total of {len(all_archives)} were checked")
-        if len(all_archives) == 0:
-            logger.error(f"请添加画廊后再添加Tags")
-            logger.error(f"Please add gallery before adding Tags")
-            sys.exit(1)
+            async with session.get(lan_url) as response:
+                all_archives = await response.json(content_type=None)
 
-        with tqdm(total=len(all_archives)) as progress_bar:
-            with sqlite3.connect(self.dbs_name) as co:
-                for sub_archives in all_archives:
-                    try:
-                        gid = re.compile('.*gid:([0-9]*),.*').match(str(sub_archives['tags']))
-                        if gid is not None:
-                            gid = int(gid.group(1))
-                        else:
-                            gid = int(str(sub_archives['title']).split('-')[0])
-                    except ValueError:
-                        logger.warning(
-                            f"The ID does not exist>> arcid: {str(sub_archives['arcid'])}, title: {str(sub_archives['title'])}")
-                        sys.exit(1)
+            logger.info(f"一共检查到 {len(all_archives)} 个")
+            logger.info(f"A total of {len(all_archives)} were checked")
+            if len(all_archives) == 0:
+                logger.error(f"请添加画廊后再添加Tags")
+                logger.error(f"Please add gallery before adding Tags")
+                sys.exit(1)
 
-                    # 根据 gid 查询数据库
-                    co = co.execute(
-                        f'SELECT eh.gid,eh.token,eh.title,eh.title_jpn,eh.category,eh.posted,eh.tags,fn.fav_name '
-                        f'FROM eh_data AS eh, fav_category AS fc, fav_name AS fn WHERE eh.gid="{gid}" AND fc.gid="{gid}" '
-                        f'AND fc.fav_id=fn.fav_id')
-                    fav_info = co.fetchone()
+            with tqdm(total=len(all_archives)) as progress_bar:
+                with sqlite3.connect(self.dbs_name) as co:
+                    for sub_archives in all_archives:
+                        try:
+                            gid = re.compile('.*gid:([0-9]*),.*').match(str(sub_archives['tags']))
+                            if gid is not None:
+                                gid = int(gid.group(1))
+                            else:
+                                gid = int(str(sub_archives['title']).split('-')[0])
+                        except ValueError:
+                            logger.warning(
+                                f"The ID does not exist>> arcid: {str(sub_archives['arcid'])}, title: {str(sub_archives['title'])}")
+                            sys.exit(1)
 
-                    # fav_category表中不存在该 gid , 则在eh_data表中查询↓↓↓
-                    if fav_info is None:
+                        # 根据 gid 查询数据库
                         co = co.execute(
-                            f'SELECT eh.gid,eh.token,eh.title,eh.title_jpn,eh.category,eh.posted,eh.tags '
-                            f'FROM eh_data AS eh WHERE eh.gid="{gid}"')
+                            f'SELECT eh.gid,eh.token,eh.title,eh.title_jpn,eh.category,eh.posted,fn.fav_name '
+                            f'FROM eh_data AS eh, fav_category AS fc, fav_name AS fn WHERE eh.gid="{gid}" AND fc.gid="{gid}" '
+                            f'AND fc.fav_id=fn.fav_id')
                         fav_info = co.fetchone()
 
+                        # fav_category表中不存在该 gid , 则在eh_data表中查询↓↓↓
                         if fav_info is None:
-                            logger.warning(f"The ID does not exist>> {gid}")
-                            continue
+                            co = co.execute(
+                                f'SELECT eh.gid,eh.token,eh.title,eh.title_jpn,eh.category,eh.posted '
+                                f'FROM eh_data AS eh WHERE eh.gid="{gid}"')
+                            fav_info = co.fetchone()
+
+                            if fav_info is None:
+                                logger.warning(f"The ID does not exist>> {gid}")
+                                continue
+                            else:
+                                fav_info = fav_info + ("no_category",)
+                                logger.warning(
+                                    f"The data does not exist in fav_category, but it exists in eh_data. The data has been "
+                                    f"written.>> {gid}")
+
+                        token = str(fav_info[1])
+
+                        # 优先使用 title_jpn 作为标题
+                        # title = str(gid) + "-" + str(fav_info[2])
+                        if fav_info[3] is not None and fav_info[3] != "":
+                            title = str(fav_info[3])
                         else:
-                            fav_info = fav_info + ("no_category",)
-                            logger.warning(
-                                f"The data does not exist in fav_category, but it exists in eh_data. The data has been "
-                                f"written.>> {gid}")
+                            title = str(fav_info[2])
 
-                    token = str(fav_info[1])
+                        source = f"exhentai.org/g/{gid}/{token}"
 
-                    # 优先使用 title_jpn 作为标题
-                    # title = str(gid) + "-" + str(fav_info[2])
-                    if fav_info[3] is not None and fav_info[3] != "":
-                        title = str(fav_info[3])
-                    else:
-                        title = str(fav_info[2])
+                        category = str(fav_info[4])
 
-                    source = f"exhentai.org/g/{gid}/{token}"
+                        # posted = str(datetime.datetime.fromtimestamp(int(db_tags[3]))).split(" ")[0].replace("-", "/")
+                        posted = fav_info[5]
 
-                    category = str(fav_info[4])
+                        # 使用 LANraragi 生成的 pages
+                        # https://github.com/Difegue/LANraragi/issues/586
+                        pages = int(sub_archives['pagecount'])
 
-                    # posted = str(datetime.datetime.fromtimestamp(int(db_tags[3]))).split(" ")[0].replace("-", "/")
-                    posted = fav_info[5]
+                        fav_name = ""
+                        if len(fav_info) > 6:
+                            fav_name = "fav_name:" + str(fav_info[6])
 
-                    # 使用 LANraragi 生成的 pages
-                    # https://github.com/Difegue/LANraragi/issues/586
-                    pages = int(sub_archives['pagecount'])
+                        # 获取 tid 列表 / Get tid_list
+                        tid_list = co.execute(f'SELECT tid FROM gid_tid WHERE gid="{gid}"').fetchall()
+                        tid_list = [tid[0] for tid in tid_list]
 
-                    tags = str(fav_info[6]).replace("[", "").replace("]", "").replace("'", "")
+                        # 在 tag_list 中查询对应 tag
+                        placeholders = ','.join(['?'] * len(tid_list))
+                        tag_list = co.execute(f'SELECT tag FROM tag_list WHERE tid IN ({placeholders})',
+                                              tid_list).fetchall()
+                        db_tags = [tag[0] for tag in tag_list]
+                        tags = ','.join(db_tags)
 
-                    fav_name = str(fav_info[7])
+                        lan_tags = f"gid:{gid},token:{token},source:{source},category:{category},date_added:{posted},pages:{pages},{fav_name}," + tags
 
-                    lan_tags = f"gid:{gid},token:{token},source:{source},category:{category},date_added:{posted},pages:{pages},fav_name:{fav_name}," + tags
-
-                    async with session.put(f"{lan_url}/{sub_archives['arcid']}/metadata",
-                                           data={"title": title, "tags": lan_tags.strip()}) as response:
-                        await response.read()
-                        progress_bar.update(1)
+                        async with session.put(f"{lan_url}/{sub_archives['arcid']}/metadata",
+                                               data={"title": title, "tags": lan_tags.strip()}) as response:
+                            await response.read()
+                            progress_bar.update(1)
 
         logger.info("[OK] LANraragi Add Tags")
 


### PR DESCRIPTION
> fix & feat

- 达到配额之后没有抛出IP quota exhausted，只是返回的地址会变成509.gif，使下载的图片变成509错误图。我不知道是不是只有我有这个问题。

- 可以添加一个显示ip浏览配额的功能，这样对固定ip访问的用户应该会更友好，也方便时刻检查ip配额

- 有时候得到的图片地址列表为空，仍旧返回了空的列表进行下载。无法获取正常图片这一情况在等待一定时间后(约几个小时)恢复正常，不知道如何解决。也不知道是不是只有我这里有这个问题

- 部分画廊的图片文件名存在重复的情况，不应该错误地跳过下载，只想到存在重复的情况下使用哈希校验判断的方法，但是好像还是有错误地跳过一些图片（

> breaking changes

- 修改了数据库结构，把tag数据独立出来 (在 sqlite 有一定性能影响)
   - 对 tag_list 添加了 tag 汉化(执行 AddFavData.translate_tags())
   - 映射表适配 tag 数据和本子的删减(执行 add_tags_data(True) )
   - gid_tid 映射表数据有不完整的情况，尝试做了一定的优化修复( 好像还有点问题 )
   - CreateComicInfo.xml 适配了修改后的数据库结构
 
以上内容对应的 commit 均只做了基础的测试，尤其是数据库结构的修改